### PR TITLE
Back quote command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following commands have been implemented:
 **extension.embraceAngleBrackets** | Surround with Angle Brackets | `< >` | `ctrl+k,a` |
 **extension.embraceSingleQuotes** | Surround with Single Quotes | `' '` | `ctrl+k,q` |
 **extension.embraceDoubleQuotes** | Surround with Double Quotes | `" "` | `ctrl+k,o` |
+**extension.embraceBackQuotes** | Surround with Back Quotes | `` ` ` `` | `ctrl+k,b` |
 | | |
 
 -----------------------------------------------------------------------------------------------------------
@@ -62,6 +63,11 @@ To configure your own keyboard shortcuts, open the Command Palette with `ctrl+sh
         {
             "key": "ctrl+k ctrl+o",
             "command": "extension.embraceDoubleQuotes",
+            "when": "editorHasSelection && editorTextFocus"
+        },
+        {
+            "key": "ctrl+k ctrl+b",
+            "command": "extension.embraceBackQuotes",
             "when": "editorHasSelection && editorTextFocus"
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ export function activate(context: vscode.ExtensionContext) {
     const disposable4 = vscode.commands.registerTextEditorCommand('extension.embraceAngleBrackets', (textEditor, edit) => { doSurround(textEditor, edit, '<', '>'); });
     const disposable5 = vscode.commands.registerTextEditorCommand('extension.embraceSingleQuotes', (textEditor, edit) => { doSurround(textEditor, edit, '\'', '\''); });
     const disposable6 = vscode.commands.registerTextEditorCommand('extension.embraceDoubleQuotes', (textEditor, edit) => { doSurround(textEditor, edit, '\"', '\"'); });
+    const disposable7 = vscode.commands.registerTextEditorCommand('extension.embraceBackQuotes', (textEditor, edit) => { doSurround(textEditor, edit, '\`', '\`'); });
 
     context.subscriptions.push(disposable1);
     context.subscriptions.push(disposable2);
@@ -17,6 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(disposable4);
     context.subscriptions.push(disposable5);
     context.subscriptions.push(disposable6);
+    context.subscriptions.push(disposable7);
 }
 
 export function deactivate() {


### PR DESCRIPTION
Adds a new command for back quotes `` ` ` ``

I added this command because I need it for JavaScript Template String which is surrounded by those back quotes.

Thanks